### PR TITLE
ENH: 1st-order sections as 1st-order coefficients

### DIFF
--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -2102,11 +2102,16 @@ def sosfilt(sos, x, axis=-1, zi=None):
         use_zi = False
 
     for section in range(n_sections):
+        b = sos[section, :3]
+        a = sos[section, 3:]
+        if b[2] == a[2] == 0:
+            # First-order section
+            b = b[:2]
+            a = a[:2]
         if use_zi:
-            x, zf[section] = lfilter(sos[section, :3], sos[section, 3:],
-                                     x, axis, zi=zi[section])
+            x, zf[section] = lfilter(b, a, x, axis, zi=zi[section])
         else:
-            x = lfilter(sos[section, :3], sos[section, 3:], x, axis)
+            x = lfilter(b, a, x, axis)
     out = (x, zf) if use_zi else x
     return out
 


### PR DESCRIPTION
Save a little bit of processing time by throwing away trailing zeros so the 1st-order sections are implemented as actual first-order filters, rather than wasting time multiplying by zeros:

```
x = randn(100000)
sos = array([[ 0.1667,  0.3333,  0.1667,  1.    ,  0.    ,  0.3333],
             [ 1.    ,  1.    ,  0.    ,  1.    ,  0.    ,  0.    ]])

timeit sosfilt(sos, x) # original
100 loops, best of 3: 3.12 ms per loop

timeit sosfilt(sos, x) # modified
100 loops, best of 3: 2.6 ms per loop
```

I think defining b and a makes the filtering lines more clear anyway
