### PR TITLE
DOC: signal: Tweak sosfilt example to ensure an illustrative plot is generated.

### DIFF
--- a/scipy/signal/signaltools.py
+++ b/scipy/signal/signaltools.py
@@ -2112,6 +2112,10 @@ def sosfilt(sos, x, axis=-1, zi=None):
         If `zi` is None, this is not returned, otherwise, `zf` holds the
         final filter delay values.
 
+    See Also
+    --------
+    zpk2sos, sos2zpk, sosfilt_zi
+
     Notes
     -----
     The filter function is implemented as a series of second-order filters
@@ -2122,23 +2126,24 @@ def sosfilt(sos, x, axis=-1, zi=None):
 
     Examples
     --------
-    Plot a 6th-order filter's impulse response using both `lfilter` and
+    Plot a 13th-order filter's impulse response using both `lfilter` and
     `sosfilt`, showing the instability that results from trying to do a
-    6th-order filter in a single stage (the numerical error pushes some poles
+    13th-order filter in a single stage (the numerical error pushes some poles
     outside of the unit circle):
 
-    >>> b, a = butter(6, [0.10, 0.105], 'band', output='ba')
-    >>> sos = butter(6, [0.10, 0.105], 'band', output='sos')
-    >>> x = zeros(1500)
+    >>> import matplotlib.pyplot as plt
+    >>> from scipy import signal
+    >>> b, a = signal.ellip(13, 0.009, 80, 0.05, output='ba')
+    >>> sos = signal.ellip(13, 0.009, 80, 0.05, output='sos')
+    >>> x = np.zeros(700)
     >>> x[0] = 1.
-    >>> y_tf = lfilter(b, a, x)
-    >>> y_sos = sosfilt(sos, x)
-    >>> plot(y_tf, 'r')
-    >>> plot(y_sos, 'k')
+    >>> y_tf = signal.lfilter(b, a, x)
+    >>> y_sos = signal.sosfilt(sos, x)
+    >>> plt.plot(y_tf, 'r', label='TF')
+    >>> plt.plot(y_sos, 'k', label='SOS')
+    >>> plt.legend(loc='best')
+    >>> plt.show()
 
-    See also
-    --------
-    zpk2sos, sos2zpk, sosfilt_zi
     """
 
     sos = atleast_2d(sos)


### PR DESCRIPTION
This fixes the example code so that a plot is included in the HTML docs.  I used a different filter with different parameters so the plot clearly shows the "correct" impulse response generated using the SOS filter and the unstable impulse response generated using the full transfer function.
